### PR TITLE
fr.po: fixed typo: 'git branch', not 'git branche'

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -3592,7 +3592,7 @@ msgstr ""
 "moment\n"
 "de le faire avec :\n"
 "\n"
-"git branche nouvelle_branche %s\n"
+"git branch nouvelle_branche %s\n"
 "\n"
 
 #: builtin/checkout.c:760


### PR DESCRIPTION
Bonjour Jean-Noël,

Tout d'abord, merci de maintenir les traductions françaises ici pour Git.
Voici juste une micro correction, rien de bien grave.
S'il y a un soucis dans la procédure, n'hésitez pas à m'avertir.

Bonne journée,

Matth
