### PR TITLE
l10n: fr.po fix translation of command usage

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -6172,7 +6172,7 @@ msgstr "affiche les tailles dans un format humainement lisible"
 
 #: builtin/describe.c:17
 msgid "git describe [<options>] [<commit-ish>...]"
-msgstr "git describe [<options>] <commit ou apparenté>*"
+msgstr "git describe [<options>] [<commit ou apparenté>...]"
 
 #: builtin/describe.c:18
 msgid "git describe [<options>] --dirty"


### PR DESCRIPTION
Fix translation of git describe command usage in order to follow other
instances of the syntax.

Signed-off-by: Vasco Almeida <vascomalmeida@sapo.pt>