### PR TITLE
Change translation of "First, rewinding"

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -14721,8 +14721,7 @@ msgstr "Changements de $mb sur $onto :"
 
 #: git-rebase.sh:615
 msgid "First, rewinding head to replay your work on top of it..."
-msgstr ""
-"Premièrement, rembobinons head pour rejouer votre travail par-dessus..."
+msgstr "Rembobinage préalable de head pour pouvoir rejouer votre travail par-dessus..."
 
 #: git-rebase.sh:625
 #, sh-format


### PR DESCRIPTION
En français premièrement attends un "secondement".
Et la seconde phrase étant "Application" on passe de "rembobinons" à "rembobinage"

Avant
```
Premièrement, rembobinons head pour rejouer votre travail par-dessus...
Application de  internal: Making foo
```

Après
```
Avant toute chose, rembobinage de head pour rejouer votre travail par-dessus...
Application de  internal: Making foo
```

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
