### PR TITLE
l10n: fr.po fixed inconsistencies

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -3996,7 +3996,7 @@ msgstr "<chemin>"
 
 #: diff.c:5616
 msgid "show the change in the specified path first"
-msgstr "afficher la modification dans les fichier spécifié en premier"
+msgstr "afficher la modification dans le chemin spécifié en premier"
 
 #: diff.c:5619
 msgid "skip the output to the specified path"


### PR DESCRIPTION
Bonjour,

J'observe que la traduction pour "specified path" à la ligne en surbrillance n'est pas comme dans l'entrée suivante.  D'après les fichiers README et TEAMS dans le dépôt jnavila/git-manpages-l10n, j'envoie cette Pull Request.

Bonne fin de journée,
Vincent TAM