### PR TITLE
l10n: fr.po: Minor improvements.

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -50,7 +50,8 @@
 #   mapping          |  mise en correspondance
 #   merge            |  fusion
 #   pack             |  paquet
-#   patches          |  patchs
+#   patch (v)        |  appliquer une/des rustine(s)
+#   patches          |  rustines
 #   pattern          |  motif
 #   to prune         |  élaguer
 #   to push          |  pousser
@@ -175,7 +176,7 @@ msgid "No changes.\n"
 msgstr "Aucune modification.\n"
 
 msgid "Patch update"
-msgstr "Mise à jour par patch"
+msgstr "Mise à jour par rustine"
 
 msgid "Review diff"
 msgstr "Réviser la différence"
@@ -273,7 +274,7 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "staging."
 msgstr ""
-"Si le patch s'applique proprement, la section éditée sera immédiatement "
+"Si la rustine s'applique proprement, la section éditée sera immédiatement "
 "marquée comme indexée."
 
 msgid ""
@@ -309,7 +310,7 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "stashing."
 msgstr ""
-"Si le patch s'applique proprement, la section éditée sera immédiatement "
+"Si la rustine s'applique proprement, la section éditée sera immédiatement "
 "marquée comme remisée."
 
 msgid ""
@@ -345,7 +346,7 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "unstaging."
 msgstr ""
-"Si le patch s'applique proprement, la section éditée sera immédiatement "
+"Si la rustine s'applique proprement, la section éditée sera immédiatement "
 "marquée comme desindexée."
 
 msgid ""
@@ -381,7 +382,7 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "applying."
 msgstr ""
-"Si le patch s'applique proprement, la section éditée sera immédiatement "
+"Si la rustine s'applique proprement, la section éditée sera immédiatement "
 "marquée comme appliquée."
 
 msgid ""
@@ -417,7 +418,7 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "discarding."
 msgstr ""
-"Si le patch s'applique proprement, la section éditée sera immédiatement "
+"Si la rustine s'applique proprement, la section éditée sera immédiatement "
 "marquée comme éliminée."
 
 msgid ""
@@ -892,10 +893,10 @@ msgid "'%s' outside a repository"
 msgstr "'%s' hors d'un dépôt"
 
 msgid "failed to read patch"
-msgstr "impossible de lire le patch"
+msgstr "impossible de lire la rustine"
 
 msgid "patch too large"
-msgstr "le patch est trop gros"
+msgstr "la rustine est trop grosse"
 
 #, c-format
 msgid "Cannot prepare timestamp regexp %s"
@@ -907,7 +908,7 @@ msgstr "regexec a retourné %d pour l'entrée : %s"
 
 #, c-format
 msgid "unable to find filename in patch at line %d"
-msgstr "nom de fichier du patch introuvable à la ligne %d"
+msgstr "nom de fichier de la rustine introuvable à la ligne %d"
 
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null, got %s on line %d"
@@ -965,7 +966,7 @@ msgstr "recomptage : ligne inattendue : %.*s"
 
 #, c-format
 msgid "patch fragment without header at line %d: %.*s"
-msgstr "fragment de patch sans en-tête à la ligne %d : %.*s"
+msgstr "fragment de rustine sans en-tête à la ligne %d : %.*s"
 
 msgid "new file depends on old contents"
 msgstr "le nouveau fichier dépend de contenus anciens"
@@ -975,7 +976,7 @@ msgstr "le fichier supprimé a encore du contenu"
 
 #, c-format
 msgid "corrupt patch at line %d"
-msgstr "patch corrompu à la ligne %d"
+msgstr "rustine corrompue à la ligne %d"
 
 #, c-format
 msgid "new file %s depends on old contents"
@@ -991,15 +992,15 @@ msgstr "** attention : le fichier %s devient vide mais n'est pas supprimé"
 
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
-msgstr "patch binaire corrompu à la ligne %d : %.*s"
+msgstr "rustine binaire corrompue à la ligne %d : %.*s"
 
 #, c-format
 msgid "unrecognized binary patch at line %d"
-msgstr "patch binaire non reconnu à la ligne %d"
+msgstr "rustine binaire non reconnue à la ligne %d"
 
 #, c-format
 msgid "patch with only garbage at line %d"
-msgstr "patch totalement incompréhensible à la ligne %d"
+msgstr "rustine totalement incompréhensible à la ligne %d"
 
 #, c-format
 msgid "unable to read symlink %s"
@@ -1033,28 +1034,29 @@ msgstr ""
 
 #, c-format
 msgid "missing binary patch data for '%s'"
-msgstr "données de patch binaire manquantes pour '%s'"
+msgstr "données de rustine binaire manquantes pour '%s'"
 
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
-"impossible d'appliquer l'inverse d'un patch binaire à '%s' sans la section "
+"impossible d'appliquer l'inverse d'une rustine binaire à '%s' sans la section "
 "inverse"
 
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
 msgstr ""
-"impossible d'appliquer un patch binaire à '%s' sans la ligne complète d'index"
+"impossible d'appliquer une rustine binaire à '%s' sans la ligne complète "
+"d'index"
 
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
 msgstr ""
-"le patch s'applique à '%s' (%s), ce qui ne correspond pas au contenu actuel."
+"la rustine s'applique à '%s' (%s), ce qui ne correspond pas au contenu actuel."
 
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
-msgstr "le patch s'applique à un '%s' vide mais ce n'est pas vide"
+msgstr "la rustine s'applique à un '%s' vide mais ce n'est pas vide"
 
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
@@ -1062,17 +1064,17 @@ msgstr "l'image postérieure nécessaire %s pour '%s' ne peut pas être lue"
 
 #, c-format
 msgid "binary patch does not apply to '%s'"
-msgstr "le patch binaire ne s'applique par correctement à '%s'"
+msgstr "la rustine binaire ne s'applique par correctement à '%s'"
 
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
-"le patch binaire sur '%s' crée un résultat incorrect (%s attendu, mais %s "
+"la rustine binaire sur '%s' crée un résultat incorrect (%s attendu, mais %s "
 "trouvé)"
 
 #, c-format
 msgid "patch failed: %s:%ld"
-msgstr "le patch a échoué : %s:%ld"
+msgstr "l'application de la rustine a échoué : %s:%ld"
 
 #, c-format
 msgid "cannot checkout %s"
@@ -1116,18 +1118,18 @@ msgstr "Échec de l'application de la fusion à 3 points…\n"
 
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
-msgstr "Patch %s appliqué avec des conflits.\n"
+msgstr "Rustine %s appliquée avec des conflits.\n"
 
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
-msgstr "Patch %s appliqué proprement.\n"
+msgstr "Rustine %s appliquée proprement.\n"
 
 #, c-format
 msgid "Falling back to direct application...\n"
 msgstr "Retour à une application directe…\n"
 
 msgid "removal patch leaves file contents"
-msgstr "le patch de suppression laisse un contenu dans le fichier"
+msgstr "la rustine de suppression laisse un contenu dans le fichier"
 
 #, c-format
 msgid "%s: wrong type"
@@ -1164,11 +1166,11 @@ msgstr "le fichier affecté '%s' est au-delà d'un lien symbolique"
 
 #, c-format
 msgid "%s: patch does not apply"
-msgstr "%s : le patch ne s'applique pas"
+msgstr "%s : la rustine ne s'applique pas"
 
 #, c-format
 msgid "Checking patch %s..."
-msgstr "Vérification du patch %s..."
+msgstr "Vérification de la rustine %s..."
 
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
@@ -1197,7 +1199,7 @@ msgstr "suppression de %s dans l'index impossible"
 
 #, c-format
 msgid "corrupt patch for submodule %s"
-msgstr "patch corrompu pour le sous-module %s"
+msgstr "rustine corrompue pour le sous-module %s"
 
 #, c-format
 msgid "unable to stat newly created file '%s'"
@@ -1227,7 +1229,7 @@ msgstr "écriture du fichier '%s' mode %o impossible"
 
 #, c-format
 msgid "Applied patch %s cleanly."
-msgstr "Patch %s appliqué proprement."
+msgstr "Rustine %s appliquée proprement."
 
 msgid "internal error"
 msgstr "erreur interne"
@@ -1235,8 +1237,8 @@ msgstr "erreur interne"
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
-msgstr[0] "Application du patch %%s avec %d rejet..."
-msgstr[1] "Application du patch %%s avec %d rejets..."
+msgstr[0] "Application de la rustine %%s avec %d rejet..."
+msgstr[1] "Application de la rustine %%s avec %d rejets..."
 
 #, c-format
 msgid "cannot open %s"
@@ -1259,14 +1261,14 @@ msgid "Skipped patch '%s'."
 msgstr "Chemin '%s' non traité."
 
 msgid "No valid patches in input (allow with \"--allow-empty\")"
-msgstr "Pas de patch valide sur l'entrée (permis avec \"--allow-empty\")"
+msgstr "Pas de rustine valide sur l'entrée (permis avec \"--allow-empty\")"
 
 msgid "unable to read index file"
 msgstr "lecture du fichier d'index impossible"
 
 #, c-format
 msgid "can't open patch '%s': %s"
-msgstr "ouverture impossible du patch '%s' :%s"
+msgstr "ouverture impossible de la rustine '%s' :%s"
 
 #, c-format
 msgid "squelched %d whitespace error"
@@ -1302,35 +1304,35 @@ msgid "remove <num> leading slashes from traditional diff paths"
 msgstr "supprimer <num> barres obliques des chemins traditionnels de diff"
 
 msgid "ignore additions made by the patch"
-msgstr "ignorer les additions réalisées par le patch"
+msgstr "ignorer les additions réalisées par la rustine"
 
 msgid "instead of applying the patch, output diffstat for the input"
-msgstr "au lieu d'appliquer le patch, afficher le diffstat de l'entrée"
+msgstr "au lieu d'appliquer la rustine, afficher le diffstat de l'entrée"
 
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 "afficher le nombre de lignes ajoutées et supprimées en notation décimale"
 
 msgid "instead of applying the patch, output a summary for the input"
-msgstr "au lieu d'appliquer le patch, afficher un résumé de l'entrée"
+msgstr "au lieu d'appliquer la rustine, afficher un résumé de l'entrée"
 
 msgid "instead of applying the patch, see if the patch is applicable"
-msgstr "au lieu d'appliquer le patch, voir si le patch est applicable"
+msgstr "au lieu d'appliquer la rustine, voir si la rustine est applicable"
 
 msgid "make sure the patch is applicable to the current index"
-msgstr "s'assurer que le patch est applicable sur l'index actuel"
+msgstr "s'assurer que la rustine est applicable sur l'index actuel"
 
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "marquer les nouveaux fichiers `git add --intent-to-add`"
 
 msgid "apply a patch without touching the working tree"
-msgstr "appliquer les patch sans toucher à la copie de travail"
+msgstr "appliquer les rustines sans toucher à la copie de travail"
 
 msgid "accept a patch that touches outside the working area"
-msgstr "accepter un patch qui touche hors de la copie de travail"
+msgstr "accepter une rustine qui touche hors de la copie de travail"
 
 msgid "also apply the patch (use with --stat/--summary/--check)"
-msgstr "appliquer aussi le patch (à utiliser avec --stat/--summary/--check)"
+msgstr "appliquer aussi la rustine (à utiliser avec --stat/--summary/--check)"
 
 msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr ""
@@ -1367,7 +1369,7 @@ msgid "ignore changes in whitespace when finding context"
 msgstr "ignorer des modifications d'espace lors de la recherche de contexte"
 
 msgid "apply the patch in reverse"
-msgstr "appliquer le patch en sens inverse"
+msgstr "appliquer la rustine en sens inverse"
 
 msgid "don't expect at least one line of context"
 msgstr "ne pas s'attendre à au moins une ligne de contexte"
@@ -1929,14 +1931,14 @@ msgid "could not read the index"
 msgstr "impossible de lire l'index"
 
 msgid "editing patch failed"
-msgstr "échec de l'édition du patch"
+msgstr "échec de l'édition de la rustine"
 
 #, c-format
 msgid "could not stat '%s'"
 msgstr "impossible de stat '%s'"
 
 msgid "empty patch. aborted"
-msgstr "patch vide. abandon"
+msgstr "rustine vide. abandon"
 
 #, c-format
 msgid "could not apply '%s'"
@@ -2109,10 +2111,10 @@ msgstr "impossible d'ouvrir '%s' en écriture"
 
 #, c-format
 msgid "could not parse patch '%s'"
-msgstr "impossible d'analyser le patch '%s'"
+msgstr "impossible d'analyser la rustine '%s'"
 
 msgid "Only one StGIT patch series can be applied at once"
-msgstr "Seulement une série de patchs StGIT peut être appliquée à la fois"
+msgstr "Seulement une série de rustines StGIT peut être appliquée à la fois"
 
 msgid "invalid timestamp"
 msgstr "horodatage invalide"
@@ -2124,14 +2126,14 @@ msgid "invalid timezone offset"
 msgstr "décalage horaire invalide"
 
 msgid "Patch format detection failed."
-msgstr "Échec de détection du format du patch."
+msgstr "Échec de détection du format de la rustine."
 
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "échec de la création du répertoire '%s'"
 
 msgid "Failed to split patches."
-msgstr "Échec de découpage des patchs."
+msgstr "Échec de découpage des rustines."
 
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\".\n"
@@ -2139,20 +2141,20 @@ msgstr "Quand vous avez résolu ce problème, lancez \"%s --continue\".\n"
 
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead.\n"
-msgstr "Si vous préférez plutôt sauter ce patch, lancez \"%s --skip\".\n"
+msgstr "Si vous préférez plutôt sauter cette rustine, lancez \"%s --skip\".\n"
 
 #, c-format
 msgid ""
 "To record the empty patch as an empty commit, run \"%s --allow-empty\".\n"
 msgstr ""
-"Pour enregistrer le patch vide comme un commit vide, lancez \"%s --allow-"
+"Pour enregistrer la rustine vide comme un commit vide, lancez \"%s --allow-"
 "empty\".\n"
 
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
-"Pour restaurer la branche originale et arrêter de patcher, lancez \"%s --"
-"abort\"."
+"Pour restaurer la branche originale et arrêter d'appliquer des rustines, "
+"lancez \"%s --abort\"."
 
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
@@ -2184,11 +2186,11 @@ msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
 msgstr ""
-"Avez-vous édité le patch à la main ?\n"
+"Avez-vous édité la rustine à la main ?\n"
 "Il ne s'applique pas aux blobs enregistrés dans son index."
 
 msgid "Falling back to patching base and 3-way merge..."
-msgstr "Retour à un patch de la base et fusion à 3 points..."
+msgstr "Retour à une rustine de la base et fusion à 3 points..."
 
 msgid "Failed to merge in the changes."
 msgstr "Échec d'intégration des modifications."
@@ -2222,7 +2224,7 @@ msgstr "impossible d'écrire le fichier d'index"
 
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
-msgstr "Index sale : impossible d'appliquer des patchs (sales : %s)"
+msgstr "Index sale : impossible d'appliquer des rustines (sales : %s)"
 
 #, c-format
 msgid "Skipping: %.*s"
@@ -2233,7 +2235,7 @@ msgid "Creating an empty commit: %.*s"
 msgstr "Création d'un commit vide : %.*s"
 
 msgid "Patch is empty."
-msgstr "Le patch actuel est vide."
+msgstr "La rustine actuelle est vide."
 
 #, c-format
 msgid "Applying: %.*s"
@@ -2244,11 +2246,12 @@ msgstr "Pas de changement -- Patch déjà appliqué."
 
 #, c-format
 msgid "Patch failed at %s %.*s"
-msgstr "l'application du patch a échoué à %s %.*s"
+msgstr "l'application de la rustine a échoué à %s %.*s"
 
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
-"Utilisez 'git am --show-current-patch=diff' pour visualiser le patch en échec"
+"Utilisez 'git am --show-current-patch=diff' pour visualiser la rustine en "
+"échec"
 
 msgid "No changes - recorded it as an empty commit."
 msgstr "aucune modification - enregistré comme un commit vide."
@@ -2260,8 +2263,8 @@ msgid ""
 msgstr ""
 "Aucun changement - avez-vous oublié d'utiliser 'git add' ?\n"
 "S'il n'y a plus rien à indexer, il se peut qu'autre chose ait déjà\n"
-"introduit les mêmes changements ; vous pourriez avoir envie de sauter ce "
-"patch."
+"introduit les mêmes changements ; vous pourriez avoir envie de sauter cette "
+"rustine."
 
 msgid ""
 "You still have unmerged paths in your index.\n"
@@ -2348,34 +2351,36 @@ msgid "format"
 msgstr "format"
 
 msgid "format the patch(es) are in"
-msgstr "format de présentation des patchs"
+msgstr "format de présentation des rustines"
 
 msgid "override error message when patch failure occurs"
-msgstr "surcharger le message d'erreur lors d'un échec d'application de patch"
+msgstr ""
+"surcharger le message d'erreur lors d'un échec d'application d'une rustine"
 
 msgid "continue applying patches after resolving a conflict"
-msgstr "continuer à appliquer les patchs après résolution d'un conflit"
+msgstr "continuer à appliquer les rustines après résolution d'un conflit"
 
 msgid "synonyms for --continue"
 msgstr "synonymes de --continue"
 
 msgid "skip the current patch"
-msgstr "sauter le patch courant"
+msgstr "sauter la rustine courante"
 
 msgid "restore the original branch and abort the patching operation"
-msgstr "restaurer la branche originale et abandonner les applications de patch"
+msgstr ""
+"restaurer la branche originale et abandonner les applications de rustines"
 
 msgid "abort the patching operation but keep HEAD where it is"
-msgstr "abandonne l'opération de patch mais garde HEAD où il est"
+msgstr "abandonne l'opération de rustine mais garde HEAD où il est"
 
 msgid "show the patch being applied"
-msgstr "afficher le patch en cours d'application"
+msgstr "afficher la rustine en cours d'application"
 
 msgid "try to apply current patch again"
-msgstr "essayer d'appliquer de nouveau le patch"
+msgstr "essayer d'appliquer de nouveau la rustine"
 
 msgid "record the empty patch as an empty commit"
-msgstr "enregistrer le patch vide comme un commit vide"
+msgstr "enregistrer la rustine vide comme un commit vide"
 
 msgid "lie about committer date"
 msgstr "mentir sur la date de validation"
@@ -7896,7 +7901,7 @@ msgid "base commit shouldn't be in revision list"
 msgstr "le commit de base ne devrait pas faire partie de la liste de révisions"
 
 msgid "cannot get patch id"
-msgstr "impossible d'obtenir l'id du patch"
+msgstr "impossible d'obtenir l'id de la rustine"
 
 msgid "failed to infer range-diff origin of current series"
 msgstr ""
@@ -7909,13 +7914,13 @@ msgstr ""
 "utilisation de '%s' comme une différence d'intervalle pour la série actuelle"
 
 msgid "use [PATCH n/m] even with a single patch"
-msgstr "utiliser [PATCH n/m] même avec un patch unique"
+msgstr "utiliser [PATCH n/m] même avec une rustine unique"
 
 msgid "use [PATCH] even with multiple patches"
-msgstr "utiliser [PATCH] même avec des patchs multiples"
+msgstr "utiliser [PATCH] même avec des rustines multiples"
 
 msgid "print patches to standard out"
-msgstr "afficher les patchs sur la sortie standard"
+msgstr "afficher les rustines sur la sortie standard"
 
 msgid "generate a cover letter"
 msgstr "générer une lettre de motivation"
@@ -7931,7 +7936,7 @@ msgid "use <sfx> instead of '.patch'"
 msgstr "utiliser <sfx> au lieu de '.patch'"
 
 msgid "start numbering patches at <n> instead of 1"
-msgstr "démarrer la numérotation des patchs à <n> au lieu de 1"
+msgstr "démarrer la numérotation des rustines à <n> au lieu de 1"
 
 msgid "reroll-count"
 msgstr "reroll-count"
@@ -7975,10 +7980,10 @@ msgid "output all-zero hash in From header"
 msgstr "écrire une empreinte à zéro dans l'entête From"
 
 msgid "don't include a patch matching a commit upstream"
-msgstr "ne pas inclure un patch correspondant à un commit amont"
+msgstr "ne pas inclure de rustine correspondant à un commit amont"
 
 msgid "show patch format instead of default (patch + stat)"
-msgstr "afficher le format du patch au lieu du défaut (patch + stat)"
+msgstr "afficher le format de la rustine au lieu du défaut (rustine + stat)"
 
 msgid "Messaging"
 msgstr "Communication"
@@ -8015,10 +8020,10 @@ msgid "boundary"
 msgstr "limite"
 
 msgid "attach the patch"
-msgstr "attacher le patch"
+msgstr "attacher la rustine"
 
 msgid "inline the patch"
-msgstr "patch à l'intérieur"
+msgstr "incorporer la rustine à l'intérieur"
 
 msgid "enable message threading, styles: shallow, deep"
 msgstr ""
@@ -8034,27 +8039,27 @@ msgid "base-commit"
 msgstr "commit-de-base"
 
 msgid "add prerequisite tree info to the patch series"
-msgstr "ajouter un arbre prérequis à la série de patchs"
+msgstr "ajouter un arbre prérequis à la série de rustines"
 
 msgid "add a signature from a file"
 msgstr "ajouter une signature depuis un fichier"
 
 msgid "don't print the patch filenames"
-msgstr "ne pas afficher les noms de fichiers des patchs"
+msgstr "ne pas afficher les noms de fichiers des rustines"
 
 msgid "show progress while generating patches"
 msgstr ""
-"afficher la barre de progression durant la phase de génération des patchs"
+"afficher la barre de progression durant la phase de génération des rustines"
 
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr ""
-"afficher les modifications par rapport à <rév> dans la première page ou un "
-"patch"
+"afficher les modifications par rapport à <rév> dans la première page ou une "
+"rustine"
 
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
 "afficher les modifications par rapport à <refspec> dans la première page ou "
-"un patch"
+"une rustine"
 
 msgid "percentage by which creation is weighted"
 msgstr "pourcentage par lequel la création est pondérée"
@@ -8085,7 +8090,7 @@ msgid "could not create directory '%s'"
 msgstr "impossible de créer le répertoire '%s'"
 
 msgid "--interdiff requires --cover-letter or single patch"
-msgstr "--interdiff requiert --cover-letter ou un patch unique"
+msgstr "--interdiff requiert --cover-letter ou une rustine unique"
 
 msgid "Interdiff:"
 msgstr "Interdiff :"
@@ -8095,7 +8100,7 @@ msgid "Interdiff against v%d:"
 msgstr "Interdiff contre v%d :"
 
 msgid "--range-diff requires --cover-letter or single patch"
-msgstr "--range-diff requiert --cover-letter ou un patch unique"
+msgstr "--range-diff requiert --cover-letter ou une rustine unique"
 
 msgid "Range-diff:"
 msgstr "Diff-intervalle :"
@@ -8109,7 +8114,7 @@ msgid "unable to read signature file '%s'"
 msgstr "lecture du fichier de signature '%s' impossible"
 
 msgid "Generating patches"
-msgstr "Génération des patchs"
+msgstr "Génération des rustines"
 
 msgid "failed to create output files"
 msgstr "échec de création des fichiers en sortie"
@@ -8302,7 +8307,7 @@ msgstr ""
 
 #. TRANSLATORS: keep <> in "<" mail ">" info.
 msgid "git mailinfo [<options>] <msg> <patch> < mail >info"
-msgstr "git mailinfo [<options>] <msg> <patch> < mail >info"
+msgstr "git mailinfo [<options>] <msg> <rustine> < mail >info"
 
 msgid "keep subject"
 msgstr "garder le sujet"
@@ -9762,7 +9767,7 @@ msgid "use the stable patch-id algorithm"
 msgstr "utiliser l'algorithme stable patch-id"
 
 msgid "don't strip whitespace from the patch"
-msgstr "ne pas retirer les espaces blancs du patch"
+msgstr "ne pas retirer les espaces blancs de la rustine"
 
 msgid "git prune [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]"
 msgstr "git prune [-n] [-v] [--progress] [--expire <heure>] [--] [<head>…]"
@@ -10554,7 +10559,7 @@ msgid "continue"
 msgstr "continuer"
 
 msgid "skip current patch and continue"
-msgstr "sauter le patch courant et continuer"
+msgstr "sauter la rustine courante et continuer"
 
 msgid "abort and check out the original branch"
 msgstr "abandonner et extraire la branche d'origine"
@@ -10566,7 +10571,7 @@ msgid "edit the todo list during an interactive rebase"
 msgstr "éditer la liste à faire lors d'un rebasage interactif"
 
 msgid "show the patch file being applied or merged"
-msgstr "afficher le patch en cours d'application ou de fusion"
+msgstr "afficher la rustine en cours d'application ou de fusion"
 
 msgid "use apply strategies to rebase"
 msgstr "utiliser des stratégies d'application pour rebaser"
@@ -12803,7 +12808,7 @@ msgid "stash staged changes only"
 msgstr "remiser seulement les modifications indexées"
 
 msgid "stash in patch mode"
-msgstr "remiser en mode patch"
+msgstr "remiser en mode rustine"
 
 msgid "quiet mode"
 msgstr "mode silencieux"
@@ -14415,13 +14420,13 @@ msgid "Add file contents to the index"
 msgstr "Ajouter le contenu de fichiers dans l'index"
 
 msgid "Apply a series of patches from a mailbox"
-msgstr "Appliquer une série de patchs depuis une boîte mail"
+msgstr "Appliquer une série de rustines depuis une boîte mail"
 
 msgid "Annotate file lines with commit information"
 msgstr "Annoter les lignes du fichier avec l'information de commit"
 
 msgid "Apply a patch to files and/or to the index"
-msgstr "Appliquer une patch à des fichiers ou à l'index"
+msgstr "Appliquer une rustine à des fichiers ou à l'index"
 
 msgid "Import a GNU Arch repository into Git"
 msgstr "Importer dans Git un dépôt GNU Arch"
@@ -14573,7 +14578,7 @@ msgid "Run a Git command on a list of repositories"
 msgstr "Lance une commande Git sur une liste de dépôts"
 
 msgid "Prepare patches for e-mail submission"
-msgstr "Préparer les patchs pour soumission par courriel"
+msgstr "Préparer les rustines pour soumission par courriel"
 
 msgid "Verifies the connectivity and validity of the objects in the database"
 msgstr ""
@@ -14643,7 +14648,7 @@ msgstr "Afficher le contenu d'un objet arbre"
 
 msgid "Extracts patch and authorship from a single e-mail message"
 msgstr ""
-"Extraire le patch et l'information de d'auteur depuis un simple message de "
+"Extraire la rustine et l'information de l'auteur depuis un simple message de "
 "courriel"
 
 msgid "Simple UNIX mbox splitter program"
@@ -14706,7 +14711,7 @@ msgid "Pack heads and tags for efficient repository access"
 msgstr "Empaqueter les têtes et les étiquettes pour un accès efficace au dépôt"
 
 msgid "Compute unique ID for a patch"
-msgstr "Calculer l'ID unique d'un patch"
+msgstr "Calculer l'ID unique d'une rustine"
 
 msgid "Prune all unreachable objects from the object database"
 msgstr "Élaguer les objets inatteignables depuis la base de données des objets"
@@ -14781,7 +14786,7 @@ msgid "Remove files from the working tree and from the index"
 msgstr "Supprimer des fichiers de la copie de travail et de l'index"
 
 msgid "Send a collection of patches as emails"
-msgstr "Envoyer un ensemble de patchs comme courriels"
+msgstr "Envoyer un ensemble de rustines comme courriels"
 
 msgid "Push objects over Git protocol to another repository"
 msgstr "Pousser les objets sur un autre dépôt via le protocole Git"
@@ -16421,7 +16426,7 @@ msgid "Diff output format options"
 msgstr "Options de format de sortie de diff"
 
 msgid "generate patch"
-msgstr "générer le patch"
+msgstr "générer la rustine"
 
 msgid "<n>"
 msgstr "<n>"
@@ -21365,7 +21370,7 @@ msgstr "impossible d'appliquer %s... %s"
 
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
-msgstr "abandon de %s %s -- le contenu du patch déjà en amont\n"
+msgstr "abandon de %s %s -- le contenu de la rustine est déjà en amont\n"
 
 #, c-format
 msgid "git %s: failed to read the index"
@@ -23272,18 +23277,18 @@ msgid "You are in the middle of an am session."
 msgstr "Vous êtes au milieu d'une session am."
 
 msgid "The current patch is empty."
-msgstr "Le patch actuel est vide."
+msgstr "La rustine actuelle est vide."
 
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr "  (réglez les conflits puis lancez \"git am --continue\")"
 
 msgid "  (use \"git am --skip\" to skip this patch)"
-msgstr "  (utilisez \"git am --skip\" pour sauter ce patch)"
+msgstr "  (utilisez \"git am --skip\" pour sauter cette rustine)"
 
 msgid ""
 "  (use \"git am --allow-empty\" to record this patch as an empty commit)"
 msgstr ""
-"  (utilisez \"git am --allow-empty\" pour enregistrer le patch comme un "
+"  (utilisez \"git am --allow-empty\" pour enregistrer la rustine comme un "
 "commit vide)"
 
 msgid "  (use \"git am --abort\" to restore the original branch)"
@@ -23328,7 +23333,7 @@ msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr "  (réglez les conflits puis lancez \"git rebase --continue\")"
 
 msgid "  (use \"git rebase --skip\" to skip this patch)"
-msgstr "  (utilisez \"git rebase --skip\" pour sauter ce patch)"
+msgstr "  (utilisez \"git rebase --skip\" pour sauter cette rustine)"
 
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr "  (utilisez \"git rebase --abort\" pour extraire la branche d'origine)"
@@ -23388,7 +23393,7 @@ msgstr ""
 "  (tous les conflits sont réglés : lancez \"git cherry-pick --continue\")"
 
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
-msgstr "  (utilisez \"git cherry-pick --skip\" pour sauter ce patch)"
+msgstr "  (utilisez \"git cherry-pick --skip\" pour sauter cette rustine)"
 
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr "  (utilisez \"git cherry-pick --abort\" pour annuler le picorage)"
@@ -23410,7 +23415,7 @@ msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr "  (tous les conflits sont réglés : lancez \"git revert --continue\")"
 
 msgid "  (use \"git revert --skip\" to skip this patch)"
-msgstr "  (utilisez \"git revert --skip\" pour sauter ce patch)"
+msgstr "  (utilisez \"git revert --skip\" pour sauter cette rustine)"
 
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr "  (utilisez \"git revert --abort\" pour annuler le rétablissement)"
@@ -23734,7 +23739,7 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"Aucun fichier patch spécifié !\n"
+"Aucun fichier de rustine spécifié !\n"
 "\n"
 
 #, perl-format
@@ -23754,7 +23759,7 @@ msgid ""
 msgstr ""
 "Les lignes commençant par \"GIT:\" seront supprimées.\n"
 "Envisagez d'inclure un diffstat global ou une table des matières\n"
-"pour le patch que vous êtes en train d'écrire.\n"
+"pour la rustine que vous êtes en train d'écrire.\n"
 "\n"
 "Effacez le corps si vous ne souhaitez pas envoyer un résumé.\n"
 
@@ -23791,7 +23796,7 @@ msgid ""
 "has the template subject '*** SUBJECT HERE ***'. Pass --force if you really "
 "want to send.\n"
 msgstr ""
-"Envoi refusé parce que le patch\n"
+"Envoi refusé parce que la rustine\n"
 "\t%s\n"
 "a un sujet modèle '*** SUBJECT HERE ***'. Passez --force is vous souhaitez "
 "vraiment envoyer.\n"
@@ -23944,7 +23949,7 @@ msgid ""
 msgstr ""
 "fatal : %s : rejeté par le crochet %s\n"
 "%s\n"
-"attention : aucun patch envoyé\n"
+"attention : aucune rustine envoyée\n"
 
 #, perl-format
 msgid "unable to open %s: %s\n"
@@ -23956,7 +23961,7 @@ msgid ""
 "warning: no patches were sent\n"
 msgstr ""
 "fatal : %s : %d est plus long que 998 caractères \n"
-"attention : aucun patch envoyé\n"
+"attention : aucune rustine envoyée\n"
 
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
@@ -24103,7 +24108,7 @@ msgstr "Souhaitez-vous réellement envoyer %s ?[y|N] : "
 #~ msgstr "%s est incompatible avec toute autre option"
 
 #~ msgid "Could not write patch"
-#~ msgstr "Impossible d'écrire le patch"
+#~ msgstr "Impossible d'écrire la rustine"
 
 #, c-format
 #~ msgid "Could not stat '%s'"

--- a/po/fr.po
+++ b/po/fr.po
@@ -29,6 +29,7 @@
 #   to debug         |  déboguer
 #   debugging        |  débogage
 #   to deflate       |  compresser
+#   directory        |  répertoire
 #   email            |  courriel
 #   enlistment       |  enrôlement
 #   entry            |  élément
@@ -45,6 +46,7 @@
 #   hunk             |  section
 #   to inflate       |  décompresser
 #   to list          |  afficher
+#   loose object     |  objet esseulé
 #   mapping          |  mise en correspondance
 #   merge            |  fusion
 #   pack             |  paquet
@@ -55,8 +57,11 @@
 #   to rebase        |  rebaser
 #   scheduler        |  planificateur
 #   trailers         |  lignes terminales
-#   repository       |  dépôt
+#   regex            |  regex
+#   regular          |
+#     expression     |  expression régulière
 #   remote           |  distante (ou serveur distant)
+#   repository       |  dépôt
 #   revision         |  révision
 #   shallow          |  superficiel
 #   shell            |  interpréteur de commandes
@@ -64,6 +69,7 @@
 #   split (index)    |  index scindé
 #   stash            |  remisage
 #   to stash         |  remiser
+#   superproject     |  super-projet
 #   tag              |  étiquette
 #   template         |  modèle
 #   thread           |  fil
@@ -886,14 +892,14 @@ msgid "'%s' outside a repository"
 msgstr "'%s' hors d'un dépôt"
 
 msgid "failed to read patch"
-msgstr "impossible de lire la rustine"
+msgstr "impossible de lire le patch"
 
 msgid "patch too large"
-msgstr "la rustine est trop grosse"
+msgstr "le patch est trop gros"
 
 #, c-format
 msgid "Cannot prepare timestamp regexp %s"
-msgstr "Impossible de préparer la regexp d'horodatage %s"
+msgstr "Impossible de préparer la regex d'horodatage %s"
 
 #, c-format
 msgid "regexec returned %d for input: %s"
@@ -912,13 +918,13 @@ msgstr ""
 #, c-format
 msgid "git apply: bad git-diff - inconsistent new filename on line %d"
 msgstr ""
-"git apply : mauvais format de git-diff - nouveau nom de fichier inconsistant "
+"git apply : mauvais format de git-diff - nouveau nom de fichier incohérent "
 "à la ligne %d"
 
 #, c-format
 msgid "git apply: bad git-diff - inconsistent old filename on line %d"
 msgstr ""
-"git apply : mauvais format de git-diff - ancien nom de fichier inconsistant "
+"git apply : mauvais format de git-diff - ancien nom de fichier incohérent "
 "à la ligne %d"
 
 #, c-format
@@ -1253,7 +1259,7 @@ msgid "Skipped patch '%s'."
 msgstr "Chemin '%s' non traité."
 
 msgid "No valid patches in input (allow with \"--allow-empty\")"
-msgstr "Pas de rustine valide sur l'entrée (permis avec \"--allow-empty\")"
+msgstr "Pas de patch valide sur l'entrée (permis avec \"--allow-empty\")"
 
 msgid "unable to read index file"
 msgstr "lecture du fichier d'index impossible"
@@ -1930,7 +1936,7 @@ msgid "could not stat '%s'"
 msgstr "impossible de stat '%s'"
 
 msgid "empty patch. aborted"
-msgstr "rustine vide. abandon"
+msgstr "patch vide. abandon"
 
 #, c-format
 msgid "could not apply '%s'"
@@ -2031,7 +2037,7 @@ msgid "adding embedded git repository: %s"
 msgstr "dépôt git embarqué ajouté : %s"
 
 msgid "Use -f if you really want to add them."
-msgstr "Utilisez -f si vous voulez vraiment les ajouter<."
+msgstr "Utilisez -f si vous voulez vraiment les ajouter."
 
 msgid "adding files failed"
 msgstr "échec de l'ajout de fichiers"
@@ -2133,13 +2139,13 @@ msgstr "Quand vous avez résolu ce problème, lancez \"%s --continue\".\n"
 
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead.\n"
-msgstr "Si vous préférez plutôt sauter cette rustine, lancez \"%s --skip\".\n"
+msgstr "Si vous préférez plutôt sauter ce patch, lancez \"%s --skip\".\n"
 
 #, c-format
 msgid ""
 "To record the empty patch as an empty commit, run \"%s --allow-empty\".\n"
 msgstr ""
-"Pour enregistrer la rustine vide comme un commit vide, lancez \"%s --allow-"
+"Pour enregistrer le patch vide comme un commit vide, lancez \"%s --allow-"
 "empty\".\n"
 
 #, c-format
@@ -2238,7 +2244,7 @@ msgstr "Pas de changement -- Patch déjà appliqué."
 
 #, c-format
 msgid "Patch failed at %s %.*s"
-msgstr "l'application de la rustine a échoué à %s %.*s"
+msgstr "l'application du patch a échoué à %s %.*s"
 
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
@@ -2366,10 +2372,10 @@ msgid "show the patch being applied"
 msgstr "afficher le patch en cours d'application"
 
 msgid "try to apply current patch again"
-msgstr "essayer d'appliquer de nouveau la rustine"
+msgstr "essayer d'appliquer de nouveau le patch"
 
 msgid "record the empty patch as an empty commit"
-msgstr "enregistrer la rustine vide comme un commit vide"
+msgstr "enregistrer le patch vide comme un commit vide"
 
 msgid "lie about committer date"
 msgstr "mentir sur la date de validation"
@@ -3588,7 +3594,7 @@ msgid "blob"
 msgstr "blob"
 
 msgid "read additional mailmap entries from blob"
-msgstr "lire des entrées supplémentaires depuis un blob"
+msgstr "lire des entrées supplémentaires de mailmap depuis un blob"
 
 msgid "no contacts specified"
 msgstr "aucun contact spécifié"
@@ -4386,7 +4392,7 @@ msgstr "échec pour délier '%s'"
 
 #, c-format
 msgid "hardlink cannot be checked at '%s'"
-msgstr "le lien dur ne peut pas être vérifier à '%s'"
+msgstr "le lien dur ne peut pas être vérifié à '%s'"
 
 #, c-format
 msgid "hardlink different from source at '%s'"
@@ -5486,7 +5492,7 @@ msgid "value"
 msgstr "valeur"
 
 msgid "use default value when missing entry"
-msgstr "utiliser le valeur par défaut quand l'entrée n'existe pas"
+msgstr "utiliser la valeur par défaut quand l'entrée n'existe pas"
 
 msgid "--fixed-value only applies with 'value-pattern'"
 msgstr "--fixed-value ne s'applique qu'à 'motif-de-valeur'"
@@ -5523,7 +5529,7 @@ msgid ""
 "       Use a regexp, --add or --replace-all to change %s."
 msgstr ""
 "impossible de surcharger des valeurs multiples avec une seule valeur\n"
-"       Utilisez une regexp, --add ou --replace-all pour modifier %s."
+"       Utilisez une regex, --add ou --replace-all pour modifier %s."
 
 #, c-format
 msgid "no such section: %s"
@@ -5549,7 +5555,7 @@ msgid "get all values: key [<value-pattern>]"
 msgstr "obtenir toutes les valeurs : clé [<motif-de-valeur>]"
 
 msgid "get values for regexp: name-regex [<value-pattern>]"
-msgstr "obtenir les valeur pour la regexp : name-regex [<motif-de-valeur>]"
+msgstr "obtenir les valeurs pour la regex : name-regex [<motif-de-valeur>]"
 
 msgid "get value specific for the URL: section[.var] URL"
 msgstr "obtenir la valeur spécifique pour l'URL : section[.var] URL"
@@ -5586,7 +5592,7 @@ msgid "find the color setting: slot [<stdout-is-tty>]"
 msgstr "trouver le réglage de la couleur : slot [<stdout-est-tty>]"
 
 msgid "with --get, use default value when missing entry"
-msgstr "avec --get, utiliser le valeur par défaut quand l'entrée n'existe pas"
+msgstr "avec --get, utiliser la valeur par défaut quand l'entrée n'existe pas"
 
 msgid "--get-color and variable type are incoherent"
 msgstr "--get-color et le type de la variable sont incohérents"
@@ -5623,7 +5629,7 @@ msgstr ""
 "Les permissions de votre répertoire de socket sont trop permissives ;\n"
 "les autres utilisateurs pourraient lire vos identifiants secrets. Lancez :\n"
 "\n"
-"    chmod 0700 %s"
+"\tchmod 0700 %s"
 
 msgid "print debugging messages to stderr"
 msgstr "afficher les messages de debug sur stderr"
@@ -6450,7 +6456,7 @@ msgid "config key storing a list of repository paths"
 msgstr "clé de config qui stocke la liste des chemins de dépôts"
 
 msgid "keep going even if command fails in a repository"
-msgstr "continuer mêm si la commande échoue dans un dépôt"
+msgstr "continuer même si la commande échoue dans un dépôt"
 
 msgid "missing --config=<config>"
 msgstr "--config=<config> manquant"
@@ -6665,7 +6671,7 @@ msgid "check only connectivity"
 msgstr "ne vérifier que la connectivité"
 
 msgid "enable more strict checking"
-msgstr "activer une vérification plus strict"
+msgstr "activer une vérification plus stricte"
 
 msgid "write dangling objects in .git/lost-found"
 msgstr "écrire les objets en suspens dans .git/lost-found"
@@ -6866,7 +6872,7 @@ msgstr ""
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
-"Il y a trop d'objets seuls inaccessibles ; lancez 'git prune' pour les "
+"Il y a trop d'objets esseulés inaccessibles ; lancez 'git prune' pour les "
 "supprimer."
 
 msgid ""
@@ -8042,13 +8048,13 @@ msgstr ""
 
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr ""
-"afficher les modifications par rapport à <rév> dans la première page ou une "
-"rustine"
+"afficher les modifications par rapport à <rév> dans la première page ou un "
+"patch"
 
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
 "afficher les modifications par rapport à <refspec> dans la première page ou "
-"une rustine"
+"un patch"
 
 msgid "percentage by which creation is weighted"
 msgstr "pourcentage par lequel la création est pondérée"
@@ -8079,7 +8085,7 @@ msgid "could not create directory '%s'"
 msgstr "impossible de créer le répertoire '%s'"
 
 msgid "--interdiff requires --cover-letter or single patch"
-msgstr "--interdiff requiert --cover-letter ou une rustine unique"
+msgstr "--interdiff requiert --cover-letter ou un patch unique"
 
 msgid "Interdiff:"
 msgstr "Interdiff :"
@@ -8089,7 +8095,7 @@ msgid "Interdiff against v%d:"
 msgstr "Interdiff contre v%d :"
 
 msgid "--range-diff requires --cover-letter or single patch"
-msgstr "--range-diff requiert --cover-letter ou une rustine unique"
+msgstr "--range-diff requiert --cover-letter ou un patch unique"
 
 msgid "Range-diff:"
 msgstr "Diff-intervalle :"
@@ -8221,7 +8227,7 @@ msgid ""
 "              [-q | --quiet] [--exit-code] [--get-url] [--sort=<key>]\n"
 "              [--symref] [<repository> [<patterns>...]]"
 msgstr ""
-"git ls-remote [--brances] [--tags] [--refs] [--upload-pack=<exec>]\n"
+"git ls-remote [--branches] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "              [-q | --quiet] [--exit-code] [--get-url] [--sort=<clé>]\n"
 "              [--symref] [<dépôt> [<motif>...]]"
 
@@ -8296,7 +8302,7 @@ msgstr ""
 
 #. TRANSLATORS: keep <> in "<" mail ">" info.
 msgid "git mailinfo [<options>] <msg> <patch> < mail >info"
-msgstr "git mailinfo [<options>] <msg> <rustine> < mail >info"
+msgstr "git mailinfo [<options>] <msg> <patch> < mail >info"
 
 msgid "keep subject"
 msgstr "garder le sujet"
@@ -9756,7 +9762,7 @@ msgid "use the stable patch-id algorithm"
 msgstr "utiliser l'algorithme stable patch-id"
 
 msgid "don't strip whitespace from the patch"
-msgstr "ne pas retirer les espaces blancs de la rustine"
+msgstr "ne pas retirer les espaces blancs du patch"
 
 msgid "git prune [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]"
 msgstr "git prune [-n] [-v] [--progress] [--expire <heure>] [--] [<head>…]"
@@ -10943,7 +10949,7 @@ msgid "repository already uses '%s' format"
 msgstr "le dépôt utilise déjà le format '%s'"
 
 msgid "enable strict checking"
-msgstr "activer une vérification plus strict"
+msgstr "activer une vérification plus stricte"
 
 msgid "'git refs verify' takes no arguments"
 msgstr "'git refs verify' n'accepte aucun argument"
@@ -12454,7 +12460,7 @@ msgid ""
 "directory '%s' contains untracked files, but is not in the sparse-checkout "
 "cone"
 msgstr ""
-"le dossier '%s' contient des fichiers non-suivis, mais n'est pas dans le "
+"le répertoire '%s' contient des fichiers non-suivis, mais n'est pas dans le "
 "cone d'extraction clairsemée"
 
 #, c-format
@@ -12797,7 +12803,7 @@ msgid "stash staged changes only"
 msgstr "remiser seulement les modifications indexées"
 
 msgid "stash in patch mode"
-msgstr "remiser en mode rustine"
+msgstr "remiser en mode patch"
 
 msgid "quiet mode"
 msgstr "mode silencieux"
@@ -13191,7 +13197,7 @@ msgid ""
 "the superproject is not on any branch"
 msgstr ""
 "La branche du sous-module %s est configurée pour hériter de la branche du "
-"superprojet, mais le superprojet n'est sur aucune branche"
+"super-projet, mais le super-projet n'est sur aucune branche"
 
 #, c-format
 msgid "Unable to find current revision in submodule path '%s'"
@@ -15060,7 +15066,7 @@ msgid ""
 "disabling Bloom filters for commit-graph layer '%s' due to incompatible "
 "settings"
 msgstr ""
-"désactivation des filtres de Bloom opur la couche de graphe de commits '%s' "
+"désactivation des filtres de Bloom pour la couche de graphe de commits '%s' "
 "à cause de réglages incompatibles"
 
 msgid "commit-graph has no base graphs chunk"
@@ -16211,7 +16217,7 @@ msgstr "impossible de charger la regex île pour '%s' : %s"
 #, c-format
 msgid "island regex from config has too many capture groups (max=%d)"
 msgstr ""
-"l'expression rationnelle depuis la configuration a trop de groupes de "
+"l'expression régulière depuis la configuration a trop de groupes de "
 "capture (max=%d)"
 
 #, c-format
@@ -16415,7 +16421,7 @@ msgid "Diff output format options"
 msgstr "Options de format de sortie de diff"
 
 msgid "generate patch"
-msgstr "générer la rustine"
+msgstr "générer le patch"
 
 msgid "<n>"
 msgstr "<n>"
@@ -16736,7 +16742,7 @@ msgstr ""
 
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
-"traiter <chaîne> dans -S comme une expression rationnelle POSIX étendue"
+"traiter <chaîne> dans -S comme une expression régulière POSIX étendue"
 
 msgid "control the order in which files appear in the output"
 msgstr "contrôler l'ordre dans lequel les fichiers apparaissent dans la sortie"
@@ -18284,7 +18290,7 @@ msgstr "échec de l'écriture de l'index de multi-paquet"
 
 msgid "cannot expire packs from an incremental multi-pack-index"
 msgstr ""
-"impossible d'expirer les paquets dpuis un index multi-paquet incrémental"
+"impossible d'expirer les paquets depuis un index multi-paquet incrémental"
 
 msgid "Counting referenced objects"
 msgstr "Comptage des objets référencés"
@@ -18293,7 +18299,7 @@ msgid "Finding and deleting unreferenced packfiles"
 msgstr "Recherche et effacement des fichiers paquets non-référencés"
 
 msgid "cannot repack an incremental multi-pack-index"
-msgstr "impossible de ré-empaqueter un index multi-paquet"
+msgstr "impossible de ré-empaqueter un index multi-paquet incrémental"
 
 msgid "could not start pack-objects"
 msgstr "impossible de démarrer le groupement d'objets"
@@ -19270,7 +19276,7 @@ msgid "use <n> digits to display object names"
 msgstr "utiliser <n> chiffres pour afficher les noms des objets"
 
 msgid "prefixed path to initial superproject"
-msgstr "chemin préfixé vers le superprojet initial"
+msgstr "chemin préfixé vers le super-projet initial"
 
 msgid "how to strip spaces and #comments from message"
 msgstr "comment éliminer les espaces et les commentaires # du message"
@@ -19484,7 +19490,7 @@ msgstr ""
 msgid ""
 "pseudo-merge regex from config has too many capture groups (max=%<PRIuMAX>)"
 msgstr ""
-"l'expression rationnelle de pseudo-fusion a trop de groupes de capture "
+"l'expression régulière de pseudo-fusion a trop de groupes de capture "
 "(max=%<PRIuMAX>)"
 
 #, c-format
@@ -21359,7 +21365,7 @@ msgstr "impossible d'appliquer %s... %s"
 
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
-msgstr "abandon de %s %s -- le contenu de la rustine déjà en amont\n"
+msgstr "abandon de %s %s -- le contenu du patch déjà en amont\n"
 
 #, c-format
 msgid "git %s: failed to read the index"
@@ -23277,7 +23283,7 @@ msgstr "  (utilisez \"git am --skip\" pour sauter ce patch)"
 msgid ""
 "  (use \"git am --allow-empty\" to record this patch as an empty commit)"
 msgstr ""
-"  (utilisez \"git am --allow-empty\" pour enregistrer la rustine comme un "
+"  (utilisez \"git am --allow-empty\" pour enregistrer le patch comme un "
 "commit vide)"
 
 msgid "  (use \"git am --abort\" to restore the original branch)"
@@ -23655,7 +23661,7 @@ msgid "--dump-aliases incompatible with other options\n"
 msgstr "--dump-aliases est incompatible avec d'autres options\n"
 
 msgid "--dump-aliases and --translate-aliases are mutually exclusive\n"
-msgstr "--dump-aliases et --translate-aliases sont mutuellement exclusifs.\n"
+msgstr "--dump-aliases et --translate-aliases sont mutuellement exclusifs\n"
 
 msgid ""
 "fatal: found configuration options for 'sendmail'\n"


### PR DESCRIPTION
* Fix an occurrence of "dpuis" to "depuis".
* Add some entries in the translation index at the beginning of the file.
* Harmonize the spelling of various items based on how common each spelling or translation is throughout the file.
  * superproject -> super-projet
  * patch -> patch
  * regex / regexp -> regex
  * regular expression -> expression régulière
  * loose object -> objet esseulé
  * directory -> répertoire
* Fix various typos (e.g.: trailing ".<" or ".", "mêm" -> "même")
* Fix minor grammatical errors (e.g: "le valeur" -> "la valeur")
